### PR TITLE
Support script API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,6 +7,7 @@ Library API
 
     canape
     module
+    script
     calibration_object
     ecu_task
     recorder

--- a/docs/script.rst
+++ b/docs/script.rst
@@ -1,0 +1,6 @@
+Script
+------
+
+.. autoclass:: pycanape.script.Script
+    :members:
+    :undoc-members:

--- a/src/pycanape/cnp_api/cnp_class.py
+++ b/src/pycanape/cnp_api/cnp_class.py
@@ -20,6 +20,7 @@ TAsap3Hdl = ctypes.POINTER(tAsap3Hdl)
 TModulHdl = ctypes.c_ushort
 TRecorderID = ctypes.POINTER(ctypes.c_ulong)
 TTime = ctypes.c_ulong
+TScriptHdl = ctypes.c_ulong
 
 EVENT_CALLBACK = ctypes.WINFUNCTYPE(None, TAsap3Hdl, ctypes.c_ulong)
 

--- a/src/pycanape/cnp_api/cnp_constants.py
+++ b/src/pycanape/cnp_api/cnp_constants.py
@@ -474,3 +474,18 @@ class DBFileType(IntEnum):
     AutosarXML = 19
     System = 20
     Anonymous = 21
+
+
+class TScriptStatus(IntEnum):
+    eTScrReady = 1
+    eTScrStarting = 2
+    eTScrRunning = 3
+    eTScrSleeping = 4
+    eTScrSuspended = 5
+    eTScrTerminated = 6
+    eTScrFinishedReturn = 7
+    eTScrFinishedCancel = 8
+    eTScrFailure = 9
+    eTScrTimeout = 10
+    eTScrDelayedCompiling = 11
+    eTScrException = 12

--- a/src/pycanape/cnp_api/cnp_prototype.py
+++ b/src/pycanape/cnp_api/cnp_prototype.py
@@ -750,3 +750,82 @@ Asap3WriteCalibrationObject = CANAPEAPI.map_symbol(
     ],
     errcheck=get_last_error,
 )
+
+Asap3ExecuteScriptEx = CANAPEAPI.map_symbol(
+    func_name="Asap3ExecuteScriptEx",
+    restype=ctypes.c_bool,
+    argtypes=[
+        cnp_class.TAsap3Hdl,                    # > TAsap3Hdl hdl
+        cnp_class.TModulHdl,                    # > TModulHdl module
+        ctypes.c_bool,                          # > bool scriptFile
+        ctypes.c_char_p,                        # > const char *script
+        ctypes.POINTER(cnp_class.TScriptHdl),   # < TScriptHdl *hScript
+    ],
+    errcheck=get_last_error,
+)
+
+Asap3GetScriptResultString = CANAPEAPI.map_symbol(
+    func_name="Asap3GetScriptResultString",
+    restype=ctypes.c_bool,
+    argtypes=[
+        cnp_class.TAsap3Hdl,                    # > TAsap3Hdl hdl
+        cnp_class.TScriptHdl,                   # > TScriptHdl hScript
+        ctypes.POINTER(ctypes.c_char_p),        # < char *resultString
+        ctypes.POINTER(ctypes.c_ulong),         # < DWORD *sizeofBuffer
+    ],
+    errcheck=get_last_error,
+)
+
+Asap3GetScriptResultValue = CANAPEAPI.map_symbol(
+    func_name="Asap3GetScriptResultValue",
+    restype=ctypes.c_bool,
+    argtypes=[
+        cnp_class.TAsap3Hdl,                    # > TAsap3Hdl hdl
+        cnp_class.TScriptHdl,                   # > TScriptHdl hScript
+        ctypes.POINTER(ctypes.c_double),        # < double *Value
+    ],
+    errcheck=get_last_error,
+)
+
+Asap3GetScriptState = CANAPEAPI.map_symbol(
+    func_name="Asap3GetScriptState",
+    restype=ctypes.c_bool,
+    argtypes=[
+        cnp_class.TAsap3Hdl,                    # > TAsap3Hdl hdl
+        cnp_class.TScriptHdl,                   # > TScriptHdl hScript
+        ctypes.POINTER(cnp_class.enum_type),    # < TScriptStatus *scrstate
+        ctypes.POINTER(ctypes.c_char_p),        # < char *textBuffer
+        ctypes.POINTER(ctypes.c_ulong),         # < DWORD *sizeofBuffer
+    ],
+    errcheck=get_last_error,
+)
+
+Asap3ReleaseScript = CANAPEAPI.map_symbol(
+    func_name="Asap3ReleaseScript",
+    restype=ctypes.c_bool,
+    argtypes=[
+        cnp_class.TAsap3Hdl,                    # > TAsap3Hdl hdl
+        cnp_class.TScriptHdl,                   # > TScriptHdl hScript
+    ],
+    errcheck=get_last_error,
+)
+
+Asap3StartScript = CANAPEAPI.map_symbol(
+    func_name="Asap3StartScript",
+    restype=ctypes.c_bool,
+    argtypes=[
+        cnp_class.TAsap3Hdl,                    # > TAsap3Hdl hdl
+        cnp_class.TScriptHdl,                   # > TScriptHdl hScript
+    ],
+    errcheck=get_last_error,
+)
+
+Asap3StopScript = CANAPEAPI.map_symbol(
+    func_name="Asap3StopScript",
+    restype=ctypes.c_bool,
+    argtypes=[
+        cnp_class.TAsap3Hdl,                    # > TAsap3Hdl hdl
+        cnp_class.TScriptHdl,                   # > TScriptHdl hScript
+    ],
+    errcheck=get_last_error,
+)

--- a/src/pycanape/module.py
+++ b/src/pycanape/module.py
@@ -322,6 +322,6 @@ class Module:
             self.module_handle,
             script_file,
             script.encode(RC["ENCODING"]),
-            ctypes.byref(script_handle)
+            ctypes.byref(script_handle),
         )
         return Script(self.asap3_handle, script_handle)

--- a/src/pycanape/module.py
+++ b/src/pycanape/module.py
@@ -316,6 +316,19 @@ class Module:
         )
 
     def execute_script_ex(self, script_file: bool, script: str) -> Script:
+        """Execute a script file or a single script command.
+
+        :param script_file:
+            Declares interpretation of parameter script.
+            If 'script_file' is true, parameter 'script' is
+            interpreted as the file name of the script file
+            to be executed. If 'script_file' is false,
+            'script' is interpreted as a single script command
+        :param script:
+            A script filename or an single script command
+        :return:
+            The instance of the Script class
+        """
         script_handle = cnp_class.TScriptHdl()
         cnp_prototype.Asap3ExecuteScriptEx(
             self.asap3_handle,

--- a/src/pycanape/module.py
+++ b/src/pycanape/module.py
@@ -12,6 +12,8 @@ from .ecu_task import EcuTask
 from .calibration_object import get_calibration_object, CalibrationObject
 from .cnp_api import cnp_class, cnp_constants
 
+from .script import Script
+
 try:
     from .cnp_api import cnp_prototype
 except FileNotFoundError:
@@ -312,3 +314,14 @@ class Module:
             self.asap3_handle,
             self.module_handle,
         )
+
+    def execute_script_ex(self, script_file: bool, script: str) -> Script:
+        script_handle = cnp_class.TScriptHdl()
+        cnp_prototype.Asap3ExecuteScriptEx(
+            self.asap3_handle,
+            self.module_handle,
+            script_file,
+            script.encode(RC["ENCODING"]),
+            ctypes.byref(script_handle)
+        )
+        return Script(self.asap3_handle, script_handle)

--- a/src/pycanape/script.py
+++ b/src/pycanape/script.py
@@ -1,0 +1,88 @@
+import ctypes
+from ctypes import wintypes
+
+from . import RC
+from .cnp_api import cnp_class, cnp_constants
+
+try:
+    from .cnp_api import cnp_prototype
+except FileNotFoundError:
+    cnp_prototype = None  # type: ignore[assignment]
+
+
+class Script:
+    def __init__(
+        self,
+        asap3_handle: cnp_class.TAsap3Hdl,  # type: ignore[valid-type]
+        script_handle: cnp_class.TScriptHdl,
+    ) -> None:
+        """The :class:`~pycanape.module.Script` class is not meant to be instantiated
+        by the user. Instead, :class:`~pycanape.module.Script` instances are returned by
+        :meth:`~pycanape.module.Module.execute_script_ex`.
+
+        :param asap3_handle:
+        :param module_handle:
+        """
+        if cnp_prototype is None:
+            raise FileNotFoundError(
+                "CANape API not found. Add CANape API "
+                "location to environment variable `PATH`."
+            )
+
+        self.asap3_handle = asap3_handle
+        self.script_handle = script_handle
+
+    def get_script_state(self) -> cnp_constants.TScriptStatus:
+        scrstate = cnp_class.enum_type()
+        c_buffer = ctypes.create_string_buffer(1024)
+        c_length = ctypes.c_ulong(1024)
+        cnp_prototype.Asap3GetScriptState(
+            self.asap3_handle,
+            self.script_handle,
+            ctypes.byref(scrstate),
+            ctypes.cast(c_buffer, ctypes.c_char_p),
+            ctypes.byref(c_length)
+        )
+
+        return dict(
+            state=cnp_constants.TScriptStatus(scrstate.value),
+            msg=c_buffer.value.decode(RC["ENCODING"])
+        )
+
+    def start_script(self) -> None:
+        cnp_prototype.Asap3StartScript(
+            self.asap3_handle,
+            self.script_handle
+        )
+
+    def stop_script(self) -> None:
+        cnp_prototype.Asap3StopScript(
+            self.asap3_handle,
+            self.script_handle
+        )
+
+    def release_script(self) -> None:
+        cnp_prototype.Asap3ReleaseScript(
+            self.asap3_handle,
+            self.script_handle
+        )
+
+    def get_script_result_value(self):
+        val = ctypes.c_double()
+        cnp_prototype.Asap3GetScriptResultValue(
+            self.asap3_handle,
+            self.script_handle,
+            ctypes.byref(val)
+        )
+        return val
+
+    def get_script_result_string(self) -> str:
+        c_buffer = ctypes.create_string_buffer(1024)
+        c_length = ctypes.c_ulong(1024)
+        cnp_prototype.Asap3GetScriptResultValue(
+            self.asap3_handle,
+            self.script_handle,
+            ctypes.cast(c_buffer, ctypes.c_char_p),
+            ctypes.byref(c_length)
+        )
+        return c_buffer.value.decode(RC["ENCODING"])

--- a/src/pycanape/script.py
+++ b/src/pycanape/script.py
@@ -34,14 +34,24 @@ class Script:
 
     def get_script_state(self) -> cnp_constants.TScriptStatus:
         scrstate = cnp_class.enum_type()
-        c_buffer = ctypes.create_string_buffer(1024)
-        c_length = ctypes.c_ulong(1024)
+        # call function first time to determine max_size
+        max_size = ctypes.c_ulong(0)
         cnp_prototype.Asap3GetScriptState(
             self.asap3_handle,
             self.script_handle,
             ctypes.byref(scrstate),
-            ctypes.cast(c_buffer, ctypes.c_char_p),
-            ctypes.byref(c_length)
+            None,
+            ctypes.byref(max_size)
+        )
+
+        # call function again to retrieve data
+        c_buffer = ctypes.create_string_buffer(max_size.value)
+        cnp_prototype.Asap3GetScriptState(
+            self.asap3_handle,
+            self.script_handle,
+            ctypes.byref(scrstate),
+            c_buffer,
+            ctypes.byref(max_size)
         )
 
         return dict(
@@ -77,12 +87,21 @@ class Script:
         return val
 
     def get_script_result_string(self) -> str:
-        c_buffer = ctypes.create_string_buffer(1024)
-        c_length = ctypes.c_ulong(1024)
+        # call function first time to determine max_size
+        max_size = ctypes.c_ulong(0)
         cnp_prototype.Asap3GetScriptResultValue(
             self.asap3_handle,
             self.script_handle,
-            ctypes.cast(c_buffer, ctypes.c_char_p),
-            ctypes.byref(c_length)
+            None,
+            ctypes.byref(max_size)
+        )
+
+        # call function again to retrieve data
+        c_buffer = ctypes.create_string_buffer(max_size.value)
+        cnp_prototype.Asap3GetScriptResultValue(
+            self.asap3_handle,
+            self.script_handle,
+            c_buffer,
+            ctypes.byref(max_size)
         )
         return c_buffer.value.decode(RC["ENCODING"])

--- a/src/pycanape/script.py
+++ b/src/pycanape/script.py
@@ -32,6 +32,11 @@ class Script:
         self.script_handle = script_handle
 
     def get_script_state(self) -> cnp_constants.TScriptStatus:
+        """Returns the state of a script.
+
+        :return:
+            current state of the script
+        """
         scrstate = cnp_class.enum_type()
         max_size = ctypes.c_ulong(0)
         cnp_prototype.Asap3GetScriptState(
@@ -44,24 +49,34 @@ class Script:
         return cnp_constants.TScriptStatus(scrstate.value)
 
     def start_script(self) -> None:
+        """Starts a defined script."""
         cnp_prototype.Asap3StartScript(
             self.asap3_handle,
             self.script_handle,
         )
 
     def stop_script(self) -> None:
+        """Stops a running script."""
         cnp_prototype.Asap3StopScript(
             self.asap3_handle,
             self.script_handle,
         )
 
     def release_script(self) -> None:
+        """Removes a delcared script from the Tasklist to
+        receive the result you must use the scriptfunction
+        'SetScriptResult'."""
         cnp_prototype.Asap3ReleaseScript(
             self.asap3_handle,
             self.script_handle,
         )
 
     def get_script_result_value(self):
+        """Returns the exitcode of a script.
+
+        :return:
+            result value of the script
+        """
         val = ctypes.c_double()
         cnp_prototype.Asap3GetScriptResultValue(
             self.asap3_handle,
@@ -71,6 +86,11 @@ class Script:
         return val
 
     def get_script_result_string(self) -> str:
+        """Returns a script result.
+
+        :return:
+            result string of the script
+        """
         # call function first time to determine max_size
         max_size = ctypes.c_ulong(0)
         cnp_prototype.Asap3GetScriptResultString(

--- a/src/pycanape/script.py
+++ b/src/pycanape/script.py
@@ -3,6 +3,7 @@ from ctypes import wintypes
 
 from . import RC
 from .cnp_api import cnp_class, cnp_constants
+from typing import Dict
 
 try:
     from .cnp_api import cnp_prototype
@@ -32,7 +33,7 @@ class Script:
         self.asap3_handle = asap3_handle
         self.script_handle = script_handle
 
-    def get_script_state(self) -> cnp_constants.TScriptStatus:
+    def get_script_state(self) -> Dict[cnp_constants.TScriptStatus, str]:
         scrstate = cnp_class.enum_type()
         # call function first time to determine max_size
         max_size = ctypes.c_ulong(0)

--- a/src/pycanape/script.py
+++ b/src/pycanape/script.py
@@ -1,9 +1,7 @@
 import ctypes
-from ctypes import wintypes
 
 from . import RC
 from .cnp_api import cnp_class, cnp_constants
-from typing import Dict
 
 try:
     from .cnp_api import cnp_prototype
@@ -41,26 +39,26 @@ class Script:
             self.script_handle,
             ctypes.byref(scrstate),
             None,
-            ctypes.byref(max_size)
+            ctypes.byref(max_size),
         )
         return cnp_constants.TScriptStatus(scrstate.value)
 
     def start_script(self) -> None:
         cnp_prototype.Asap3StartScript(
             self.asap3_handle,
-            self.script_handle
+            self.script_handle,
         )
 
     def stop_script(self) -> None:
         cnp_prototype.Asap3StopScript(
             self.asap3_handle,
-            self.script_handle
+            self.script_handle,
         )
 
     def release_script(self) -> None:
         cnp_prototype.Asap3ReleaseScript(
             self.asap3_handle,
-            self.script_handle
+            self.script_handle,
         )
 
     def get_script_result_value(self):
@@ -68,26 +66,26 @@ class Script:
         cnp_prototype.Asap3GetScriptResultValue(
             self.asap3_handle,
             self.script_handle,
-            ctypes.byref(val)
+            ctypes.byref(val),
         )
         return val
 
     def get_script_result_string(self) -> str:
         # call function first time to determine max_size
         max_size = ctypes.c_ulong(0)
-        cnp_prototype.Asap3GetScriptResultValue(
+        cnp_prototype.Asap3GetScriptResultString(
             self.asap3_handle,
             self.script_handle,
             None,
-            ctypes.byref(max_size)
+            ctypes.byref(max_size),
         )
 
         # call function again to retrieve data
         c_buffer = ctypes.create_string_buffer(max_size.value)
-        cnp_prototype.Asap3GetScriptResultValue(
+        cnp_prototype.Asap3GetScriptResultString(
             self.asap3_handle,
             self.script_handle,
             c_buffer,
-            ctypes.byref(max_size)
+            ctypes.byref(max_size),
         )
         return c_buffer.value.decode(RC["ENCODING"])

--- a/src/pycanape/script.py
+++ b/src/pycanape/script.py
@@ -16,12 +16,12 @@ class Script:
         asap3_handle: cnp_class.TAsap3Hdl,  # type: ignore[valid-type]
         script_handle: cnp_class.TScriptHdl,
     ) -> None:
-        """The :class:`~pycanape.module.Script` class is not meant to be instantiated
-        by the user. Instead, :class:`~pycanape.module.Script` instances are returned by
+        """The :class:`~pycanape.script.Script` class is not meant to be instantiated
+        by the user. Instead, :class:`~pycanape.script.Script` instances are returned by
         :meth:`~pycanape.module.Module.execute_script_ex`.
 
         :param asap3_handle:
-        :param module_handle:
+        :param script_handle:
         """
         if cnp_prototype is None:
             raise FileNotFoundError(

--- a/src/pycanape/script.py
+++ b/src/pycanape/script.py
@@ -33,9 +33,8 @@ class Script:
         self.asap3_handle = asap3_handle
         self.script_handle = script_handle
 
-    def get_script_state(self) -> Dict[cnp_constants.TScriptStatus, str]:
+    def get_script_state(self) -> cnp_constants.TScriptStatus:
         scrstate = cnp_class.enum_type()
-        # call function first time to determine max_size
         max_size = ctypes.c_ulong(0)
         cnp_prototype.Asap3GetScriptState(
             self.asap3_handle,
@@ -44,21 +43,7 @@ class Script:
             None,
             ctypes.byref(max_size)
         )
-
-        # call function again to retrieve data
-        c_buffer = ctypes.create_string_buffer(max_size.value)
-        cnp_prototype.Asap3GetScriptState(
-            self.asap3_handle,
-            self.script_handle,
-            ctypes.byref(scrstate),
-            c_buffer,
-            ctypes.byref(max_size)
-        )
-
-        return dict(
-            state=cnp_constants.TScriptStatus(scrstate.value),
-            msg=c_buffer.value.decode(RC["ENCODING"])
-        )
+        return cnp_constants.TScriptStatus(scrstate.value)
 
     def start_script(self) -> None:
         cnp_prototype.Asap3StartScript(

--- a/src/pycanape/script.py
+++ b/src/pycanape/script.py
@@ -49,29 +49,29 @@ class Script:
         return cnp_constants.TScriptStatus(scrstate.value)
 
     def start_script(self) -> None:
-        """Starts a defined script."""
+        """Starts the script."""
         cnp_prototype.Asap3StartScript(
             self.asap3_handle,
             self.script_handle,
         )
 
     def stop_script(self) -> None:
-        """Stops a running script."""
+        """Stop the script."""
         cnp_prototype.Asap3StopScript(
             self.asap3_handle,
             self.script_handle,
         )
 
     def release_script(self) -> None:
-        """Removes a delcared script from the Tasklist to
-        receive the result you must use the scriptfunction
-        'SetScriptResult'."""
+        """Removes a declared script from the Tasklist.
+        To receive the result you must use the 'SetScriptResult' in
+        your CASL script."""
         cnp_prototype.Asap3ReleaseScript(
             self.asap3_handle,
             self.script_handle,
         )
 
-    def get_script_result_value(self):
+    def get_script_result_value(self) -> float:
         """Returns the exitcode of a script.
 
         :return:
@@ -83,7 +83,7 @@ class Script:
             self.script_handle,
             ctypes.byref(val),
         )
-        return val
+        return val.value
 
     def get_script_result_string(self) -> str:
         """Returns a script result.


### PR DESCRIPTION
Implement Scripting Functions:
bool ASAP3_EXPORT CALL_CONV  Asap3ExecuteScriptEx (TAsap3Hdl hdl, TModulHdl module, bool scriptFile, const char *script, TScriptHdl *hScript) 
  
bool ASAP3_EXPORT CALL_CONV  Asap3GetScriptState (TAsap3Hdl hdl, TScriptHdl hScript, TScriptStatus *scrstate, char *textBuffer, DWORD *sizeofbuffer)

bool ASAP3_EXPORT CALL_CONV  Asap3StopScript (TAsap3Hdl hdl, TScriptHdl hScript) 

bool ASAP3_EXPORT CALL_CONV  Asap3StartScript (TAsap3Hdl hdl, TScriptHdl hScript, char *Commandline=NULL, TModulHdl moduleHdl=ASAP3_INVALID_MODULE_HDL) 

bool ASAP3_EXPORT CALL_CONV  Asap3GetScriptResultValue (TAsap3Hdl hdl, TScriptHdl hScript, double *Value) 

bool ASAP3_EXPORT CALL_CONV  Asap3GetScriptResultString (TAsap3Hdl hdl, TScriptHdl hScript, char *resultString, DWORD *sizeofBuffer) 

bool ASAP3_EXPORT CALL_CONV  Asap3ReleaseScript (TAsap3Hdl hdl, TScriptHdl hScript) 



























